### PR TITLE
Added html5Types in persian-datepicker-tpls.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,24 @@
 {
   "name": "angular-bootstrap-persian-datepicker",
-  "version": "0.1.0",
-  "main": "./persian-datepicker-tpls.js",
-  "dependencies": {
-    "angular-ui-bootstrap": "latest"
-  },
-  "ignore": []
+  "version": "0.0.1",
+  "homepage": "https://github.com/rafialikhan/angular-bootstrap-persian-datepicker",
+  "authors": [
+    "Rafi Ali Khan <rafialikhan@gmail.com>"
+  ],
+  "description": "This is a fork of the component by AminRahimi https://github.com/AminRahimi/angular-bootstrap-persian-datepicker/blob/master/bower.json with additional modifications for HTML5 support",
+  "main": ["./persiandate.js","./persian-datepicker-tpls.js"],
+  "keywords": [
+    "Persian",
+    "Calendar",
+    "Jalali",
+    "Calendar"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
 }

--- a/persian-datepicker-tpls.js
+++ b/persian-datepicker-tpls.js
@@ -517,6 +517,11 @@ angular.module('ui.bootstrap.persian.datepicker', ['ui.bootstrap.dateparser', 'u
 .constant('datepickerPopupConfig', {
   datepickerPopupPersian: 'yyyy-MM-dd',
   currentText: 'Today',
+  html5Types: {
+    date: 'yyyy-MM-dd',
+    'datetime-local': 'yyyy-MM-ddTHH:mm:ss.sss',
+    'month': 'yyyy-MM'
+  },
   clearText: 'Clear',
   closeText: 'Done',
   closeOnDateSelection: true,


### PR DESCRIPTION
This was needed to make it work on Chrome browsers. Ignore the bower.json - updated that to submit it to bower component libraries since we are using grunt/ bower for automatic library updates.